### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,5 +1,8 @@
 name: Rust
 
+permissions:
+  contents: read
+
 on:
   push:
     branches:


### PR DESCRIPTION
Potential fix for [https://github.com/ismaileke/bedrock-client/security/code-scanning/1](https://github.com/ismaileke/bedrock-client/security/code-scanning/1)

To fix the issue, we need to add a `permissions` block to the workflow file. Since the workflow only performs basic CI tasks (building and testing Rust code), the minimal required permission is `contents: read`. This ensures that the `GITHUB_TOKEN` has only the necessary access to the repository contents, reducing the risk of unintended actions or security vulnerabilities.

The `permissions` block should be added at the root level of the workflow file, so it applies to all jobs in the workflow.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
